### PR TITLE
Add files via upload

### DIFF
--- a/extensions/asana/src/api/projects.ts
+++ b/extensions/asana/src/api/projects.ts
@@ -1,6 +1,7 @@
 import { request } from "./request";
 import { CustomField } from "./tasks";
 
+
 export type Project = {
   gid: string;
   id: string;
@@ -13,10 +14,10 @@ export type Project = {
   }[];
 };
 
-export async function getProjects(workspace: string) {
+export async function getProjects(team: string) {
   const { data } = await request<{ data: Project[] }>("/projects", {
     params: {
-      workspace,
+      team,
       opt_fields: "id,name,icon,color,custom_field_settings.custom_field",
     },
   });

--- a/extensions/asana/src/api/tasks.ts
+++ b/extensions/asana/src/api/tasks.ts
@@ -1,5 +1,6 @@
 import { request } from "./request";
 import { Project } from "./projects";
+import { Teams } from "./teams";
 
 type UserTaskList = {
   gid: string;
@@ -38,6 +39,7 @@ export type Task = {
   due_on: string | null;
   completed: boolean;
   permalink_url: string;
+  teams: Teams;
   projects: Project[];
   assignee_section: AssigneeSection;
   assignee: Assignee | null;
@@ -84,6 +86,7 @@ export async function getTask(taskId: string) {
 
 type TaskPayload = {
   workspace: string;
+  teams: string;
 } & Partial<{
   name: string;
   projects: string[];

--- a/extensions/asana/src/api/teams.ts
+++ b/extensions/asana/src/api/teams.ts
@@ -1,0 +1,16 @@
+import { request } from "./request";
+
+export type Teams = {
+  gid: string;
+  name: string;
+};
+
+export async function getTeamsForWorkspace(workspace: 1201518352966289) {
+  const { data } = await request<{ data: Teams[] }>("/teams", {
+    params: {
+        workspace,
+    },
+  });
+
+  return data.data;
+}

--- a/extensions/asana/src/components/CreateTaskForm.tsx
+++ b/extensions/asana/src/components/CreateTaskForm.tsx
@@ -3,6 +3,7 @@ import { format } from "date-fns";
 import { FormValidation, getAvatarIcon, useForm } from "@raycast/utils";
 import { useMemo } from "react";
 import { useWorkspaces } from "../hooks/useWorkspaces";
+import { useTeams } from "../hooks/useTeams";
 import { useProjects } from "../hooks/useProjects";
 import { useUsers } from "../hooks/useUsers";
 import { useMe } from "../hooks/useMe";
@@ -17,6 +18,7 @@ export default function CreateTaskForm(props: {
   draftValues?: TaskFormValues;
   assignee?: string;
   workspace?: string;
+  teams?: string;
   fromEmptyView?: boolean;
 }) {
   const { push } = useNavigation();
@@ -49,6 +51,7 @@ export default function CreateTaskForm(props: {
 
         const task = await createTask({
           workspace: values.workspace,
+          teams: values.team,
           name: values.name,
           custom_fields: customFields,
           ...(values.projects && values.projects.length > 0 ? { projects: values.projects } : {}),
@@ -87,10 +90,12 @@ export default function CreateTaskForm(props: {
     },
     validation: {
       workspace: FormValidation.Required,
+      team: FormValidation.Required,
       name: FormValidation.Required,
     },
     initialValues: {
       workspace: props.draftValues?.workspace || props.workspace,
+      team: props.draftValues?.team || props.teams,
       projects: props.draftValues?.projects,
       name: props.draftValues?.name,
       description: props.draftValues?.description,
@@ -100,7 +105,8 @@ export default function CreateTaskForm(props: {
   });
 
   const { data: workspaces } = useWorkspaces();
-  const { data: allProjects } = useProjects(values.workspace);
+  const { data: teams } = useTeams(values.workspace);
+  const { data: allProjects } = useProjects(values.team);
   const { data: users } = useUsers(values.workspace);
   const { data: me } = useMe();
 
@@ -126,9 +132,21 @@ export default function CreateTaskForm(props: {
       }
       enableDrafts={!props.fromEmptyView}
     >
-      <Form.Dropdown title="Workspace" storeValue {...itemProps.workspace}>
+      <Form.Dropdown title="Workspace" storeValue  {...itemProps.workspace}>
         {workspaces?.map((workspace) => {
           return <Form.Dropdown.Item key={workspace.gid} value={workspace.gid} title={workspace.name} />;
+        })}
+      </Form.Dropdown>
+
+      <Form.Dropdown title="Teams" storeValue autoFocus {...itemProps.team}>
+        {teams?.map((teams) => {
+          return (
+          <Form.Dropdown.Item 
+            key={teams.gid} 
+            value={teams.gid} 
+            title={teams.name} 
+            />
+          );
         })}
       </Form.Dropdown>
 
@@ -147,7 +165,7 @@ export default function CreateTaskForm(props: {
 
       <Form.Separator />
 
-      <Form.TextField title="Task Name" placeholder="Short title for the task" autoFocus {...itemProps.name} />
+      <Form.TextField title="Task Name" placeholder="Short title for the task"  {...itemProps.name} />
 
       <Form.TextArea title="Description" placeholder="Add more detail to this task" {...itemProps.description} />
 

--- a/extensions/asana/src/create-task.tsx
+++ b/extensions/asana/src/create-task.tsx
@@ -2,6 +2,7 @@ import CreateTaskForm from "./components/CreateTaskForm";
 import withAsanaAuth from "./components/withAsanaAuth";
 
 export type TaskFormValues = {
+  team: string;
   workspace: string;
   description: string;
   projects: string[];

--- a/extensions/asana/src/hooks/useProjects.ts
+++ b/extensions/asana/src/hooks/useProjects.ts
@@ -2,9 +2,9 @@ import { useCachedPromise } from "@raycast/utils";
 import { getProjects } from "../api/projects";
 import { handleUseCachedPromiseError } from "../helpers/errors";
 
-export function useProjects(workspace?: string) {
-  return useCachedPromise((workspace) => getProjects(workspace), [workspace], {
-    execute: !!workspace,
+export function useProjects(team?: string) {
+  return useCachedPromise((team) => getProjects(team), [team], {
+    execute: !!team,
     onError(error) {
       handleUseCachedPromiseError(error);
     },

--- a/extensions/asana/src/hooks/useTeams.ts
+++ b/extensions/asana/src/hooks/useTeams.ts
@@ -1,0 +1,12 @@
+import { useCachedPromise } from "@raycast/utils";
+import { getTeamsForWorkspace } from "../api/teams";
+import { handleUseCachedPromiseError } from "../helpers/errors";
+
+export function useTeams(workspace?: string) {
+  return useCachedPromise((workspace) => getTeamsForWorkspace(workspace), [workspace], {
+    execute: !!workspace,
+    onError(error) {
+      handleUseCachedPromiseError(error);
+    },
+  });
+}


### PR DESCRIPTION
## Description

Made changes to the Asana extension to include Teams. This creates a filter for Projects to only be searched under the selected Team. 

This addresses an earlier issue where the query for Projects would time out if a workspace had too many existing Projects.

## Screencast

## Checklist

- [ ✅] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [ ✅] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ✅] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [✅ ] I checked that files in the `assets` folder are used by the extension itself
- [ ✅] I checked that assets used by the `README` are placed outside of the `metadata` folder
